### PR TITLE
Add cover and revenue metrics to dashboard

### DIFF
--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/dashboard.php
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/dashboard.php
@@ -1,11 +1,19 @@
 <?php
 if (!defined('ABSPATH')) exit;
 
+// Ensure required models are loaded
+if (!class_exists('YRR_Reservation_Model') && file_exists(YRR_PLUGIN_PATH . 'models/class-reservation-model.php')) {
+    require_once YRR_PLUGIN_PATH . 'models/class-reservation-model.php';
+}
+if (!class_exists('YRR_Tables_Model') && file_exists(YRR_PLUGIN_PATH . 'models/class-tables-model.php')) {
+    require_once YRR_PLUGIN_PATH . 'models/class-tables-model.php';
+}
+
 // You can adjust these values or fetch them from your database/models.
 $res_count   = class_exists('YRR_Reservation_Model') ? YRR_Reservation_Model::get_total_count() : 0;
-//$cover_count = class_exists('YRR_Reservation_Model') ? YRR_Reservation_Model::count_covers() : 0;
-//$table_count = class_exists('YRR_Tables_Model') ? count(YRR_Tables_Model::get_all()) : 0;
-//$rev         = class_exists('YRR_Reservation_Model') ? YRR_Reservation_Model::total_revenue_this_month() : 0.00;
+$cover_count = class_exists('YRR_Reservation_Model') ? YRR_Reservation_Model::count_covers() : 0;
+$table_count = class_exists('YRR_Tables_Model') ? count(YRR_Tables_Model::get_all()) : 0;
+$rev         = class_exists('YRR_Reservation_Model') ? YRR_Reservation_Model::total_revenue_this_month() : 0.00;
 
 ?>
 


### PR DESCRIPTION
## Summary
- display cover, table, and revenue stats on admin dashboard
- implement `count_covers` and `total_revenue_this_month` in reservation model
- ensure required models are loaded before computing stats

## Testing
- `php -l views/admin/dashboard.php`
- `php -l models/class-reservation-model.php`


------
https://chatgpt.com/codex/tasks/task_b_688e3b18bd58833184378dda8bef89cc