### PR TITLE
Add nonce verification for reservation actions

### DIFF
--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/controllers/class-admin-controller.php
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/controllers/class-admin-controller.php
@@ -342,19 +342,24 @@ class YRR_Admin_Controller {
      * Process admin actions
      */
     private function process_admin_action($action) {
+        $reservation_id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+
         switch ($action) {
             case 'delete_reservation':
+                check_admin_referer('delete_reservation_' . $reservation_id);
                 $this->delete_reservation();
                 break;
-                
+
             case 'confirm_reservation':
+                check_admin_referer('confirm_reservation_' . $reservation_id);
                 $this->confirm_reservation();
                 break;
-                
+
             case 'cancel_reservation':
+                check_admin_referer('cancel_reservation_' . $reservation_id);
                 $this->cancel_reservation();
                 break;
-                
+
             default:
                 break;
         }

--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/reservations.php
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/reservations.php
@@ -337,33 +337,33 @@ $locations = YRR_Locations_Model::get_all(true);
                                     <td class="column-actions">
                                         <div class="yrr-reservation-actions">
                                             <?php if ($reservation->status === 'pending'): ?>
-                                                <a href="<?php echo wp_nonce_url(admin_url('admin.php?page=yrr-reservations&action=confirm&id=' . $reservation->id), 'confirm_reservation_' . $reservation->id); ?>" 
+                                                <a href="<?php echo esc_url( wp_nonce_url( admin_url( 'admin.php?page=yrr-reservations&action=confirm_reservation&id=' . $reservation->id ), 'confirm_reservation_' . $reservation->id ) ); ?>"
                                                    class="button button-small button-primary" title="<?php _e('Confirm Reservation', 'yrr'); ?>">
                                                     ✅ <?php _e('Confirm', 'yrr'); ?>
                                                 </a>
                                             <?php endif; ?>
-                                            
+
                                             <?php if (in_array($reservation->status, ['pending', 'confirmed'])): ?>
-                                                <a href="<?php echo wp_nonce_url(admin_url('admin.php?page=yrr-reservations&action=cancel&id=' . $reservation->id), 'cancel_reservation_' . $reservation->id); ?>" 
+                                                <a href="<?php echo esc_url( wp_nonce_url( admin_url( 'admin.php?page=yrr-reservations&action=cancel_reservation&id=' . $reservation->id ), 'cancel_reservation_' . $reservation->id ) ); ?>"
                                                    class="button button-small yrr-btn-cancel" title="<?php _e('Cancel Reservation', 'yrr'); ?>"
                                                    onclick="return confirm('<?php _e('Are you sure you want to cancel this reservation?', 'yrr'); ?>')">
                                                     ❌ <?php _e('Cancel', 'yrr'); ?>
                                                 </a>
                                             <?php endif; ?>
-                                            
+
                                             <?php if ($reservation->status === 'confirmed'): ?>
-                                                <a href="<?php echo wp_nonce_url(admin_url('admin.php?page=yrr-reservations&action=complete&id=' . $reservation->id), 'complete_reservation_' . $reservation->id); ?>" 
+                                                <a href="<?php echo esc_url( wp_nonce_url( admin_url( 'admin.php?page=yrr-reservations&action=complete_reservation&id=' . $reservation->id ), 'complete_reservation_' . $reservation->id ) ); ?>"
                                                    class="button button-small" title="<?php _e('Mark as Completed', 'yrr'); ?>">
                                                     🎉 <?php _e('Complete', 'yrr'); ?>
                                                 </a>
                                             <?php endif; ?>
-                                            
-                                            <a href="#" class="button button-small yrr-btn-edit-reservation" 
+
+                                            <a href="#" class="button button-small yrr-btn-edit-reservation"
                                                data-id="<?php echo esc_attr($reservation->id); ?>" title="<?php _e('Edit Reservation', 'yrr'); ?>">
                                                 ✏️ <?php _e('Edit', 'yrr'); ?>
                                             </a>
-                                            
-                                            <a href="<?php echo wp_nonce_url(admin_url('admin.php?page=yrr-reservations&action=delete&id=' . $reservation->id), 'delete_reservation_' . $reservation->id); ?>" 
+
+                                            <a href="<?php echo esc_url( wp_nonce_url( admin_url( 'admin.php?page=yrr-reservations&action=delete_reservation&id=' . $reservation->id ), 'delete_reservation_' . $reservation->id ) ); ?>"
                                                class="button button-small button-link-delete" title="<?php _e('Delete Reservation', 'yrr'); ?>"
                                                onclick="return confirm('<?php _e('Are you sure you want to delete this reservation? This action cannot be undone.', 'yrr'); ?>')">
                                                 🗑️ <?php _e('Delete', 'yrr'); ?>


### PR DESCRIPTION
## Summary
- secure admin reservation actions with nonce verification and mapping
- wrap confirm, cancel, and delete links in admin views with `wp_nonce_url`

## Testing
- `php -l controllers/class-admin-controller.php`
- `php -l views/admin/reservations.php`


------
https://chatgpt.com/codex/tasks/task_b_688e3b45e36c8331b0362aebfc17ae74