### PR TITLE
Add PHPUnit tests and configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+tests/.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -168,4 +168,12 @@ https://www.theaccessgroup.com/en-gb/hospitality/sectors/restaurants/reservation
 
 
 
+## Running Tests
+
+Execute the automated tests using PHPUnit:
+
+```bash
+phpunit --configuration tests/phpunit.xml
+```
+
 Additional documentation can be found in the [docs](docs/) directory.

--- a/tests/Controllers/AdminControllerTest.php
+++ b/tests/Controllers/AdminControllerTest.php
@@ -1,0 +1,17 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once YRR_PLUGIN_PATH . 'controllers/class-admin-controller.php';
+
+class AdminControllerTest extends TestCase
+{
+    public function test_enqueue_admin_assets_ignores_non_plugin_pages()
+    {
+        $controller = new YRR_Admin_Controller();
+        $GLOBALS['enqueued_styles'] = [];
+        $GLOBALS['enqueued_scripts'] = [];
+        $controller->enqueue_admin_assets('dashboard');
+        $this->assertEmpty($GLOBALS['enqueued_styles']);
+        $this->assertEmpty($GLOBALS['enqueued_scripts']);
+    }
+}

--- a/tests/Models/ReservationModelTest.php
+++ b/tests/Models/ReservationModelTest.php
@@ -1,0 +1,14 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once YRR_PLUGIN_PATH . 'models/class-reservation-model.php';
+
+class ReservationModelTest extends TestCase
+{
+    public function test_update_status_with_invalid_status_returns_wp_error()
+    {
+        $result = YRR_Reservation_Model::update_status(1, 'bogus');
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertEquals('invalid_status', $result->get_error_code());
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,45 @@
+<?php
+// Basic test bootstrap for plugin
+
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__ . '/');
+}
+
+// Minimal WP_Error implementation
+if (!class_exists('WP_Error')) {
+    class WP_Error {
+        private $code;
+        private $message;
+        public function __construct($code, $message = '') {
+            $this->code = $code;
+            $this->message = $message;
+        }
+        public function get_error_code() {
+            return $this->code;
+        }
+        public function get_error_message() {
+            return $this->message;
+        }
+    }
+}
+
+// WordPress function stubs
+function __($text, $domain = null) { return $text; }
+function wp_die($message) { throw new Exception($message); }
+function wp_parse_args($args, $defaults = array()) { return array_merge($defaults, $args); }
+function current_time($type = 'mysql') { return date('Y-m-d H:i:s'); }
+function current_user_can($capability) { return true; }
+function do_action($hook, ...$args) { /* no-op */ }
+function add_action($hook, $callback, $priority = 10, $accepted_args = 1) { /* no-op */ }
+function add_menu_page(...$args) { $GLOBALS['menu_pages'][] = $args; }
+function add_submenu_page(...$args) { $GLOBALS['submenu_pages'][] = $args; }
+
+$GLOBALS['enqueued_styles'] = [];
+$GLOBALS['enqueued_scripts'] = [];
+function wp_enqueue_style(...$args) { $GLOBALS['enqueued_styles'][] = $args; }
+function wp_enqueue_script(...$args) { $GLOBALS['enqueued_scripts'][] = $args; }
+
+// Plugin constants
+define('YRR_PLUGIN_PATH', dirname(__DIR__) . '/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/');
+define('YRR_PLUGIN_URL', '');
+define('YRR_VERSION', '1.0');

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="YRR Tests">
+            <directory suffix="Test.php">.</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
## Summary
- add PHPUnit configuration and bootstrap
- test reservation model update status validation
- test admin controller asset loading on non-plugin pages
- document running tests

## Testing
- `phpunit --configuration tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_b_688e42690f0883318237a450a31b6877