### PR TITLE
Introduce PDO database wrapper

### DIFF
--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/includes/class-database.php
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/includes/class-database.php
@@ -1,13 +1,44 @@
 <?php
 /**
+ * Simple PDO wrapper used by standalone scripts.
+ */
+class Database {
+    private $pdo;
+
+    /**
+     * Connect to the database and return a PDO instance.
+     */
+    public function connect(): PDO {
+        if ($this->pdo === null) {
+            $host = getenv('DB_HOST') ?: 'localhost';
+            $db   = getenv('DB_NAME') ?: 'yenolx';
+            $user = getenv('DB_USER') ?: 'root';
+            $pass = getenv('DB_PASS') ?: '';
+            $charset = 'utf8mb4';
+
+            $dsn = "mysql:host=$host;dbname=$db;charset=$charset";
+            $options = [
+                PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+                PDO::ATTR_EMULATE_PREPARES   => false,
+            ];
+
+            $this->pdo = new PDO($dsn, $user, $pass, $options);
+        }
+
+        return $this->pdo;
+    }
+}
+
+if (!defined('ABSPATH')) {
+    // Not running within WordPress; skip plugin-specific database management.
+    return;
+}
+
+/**
  * Database management class for Yenolx Restaurant Reservation System
  * Handles table creation, updates, and data migrations
  */
-
-if (!defined('ABSPATH')) {
-    exit('Direct access forbidden.');
-}
-
 class YRR_Database {
     
     /**


### PR DESCRIPTION
## Summary
- add standalone `Database` class with `connect()` method returning a PDO instance
- ensure class-database file can be loaded outside WordPress for API/login scripts

## Testing
- `phpunit --configuration tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_b_688e5e7d66cc8331be911e651d7c4a91