### PR TITLE
Improve login session security

### DIFF
--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/process-login.php
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/process-login.php
@@ -13,9 +13,12 @@ $stmt->execute([$username]);
 $user = $stmt->fetch(PDO::FETCH_ASSOC);
 
 if ($user && password_verify($password, $user['password'])) {
+  session_regenerate_id(true);
   $_SESSION['admin_logged_in'] = true;
   $_SESSION['admin_username'] = $username;
   header("Location: views/admin/dashboard.php");
+  exit;
 } else {
   header("Location: login.php?error=1");
+  exit;
 }

--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/process-reset-password.php
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/process-reset-password.php
@@ -36,6 +36,8 @@ try {
   $stmt->execute([$new_hashed, $user]);
 
   header("Location: reset-password.php?success=1");
+  exit;
 } catch (Exception $e) {
   header("Location: reset-password.php?error=Error: " . urlencode($e->getMessage()));
+  exit;
 }


### PR DESCRIPTION
## Summary
- Regenerate session ID after successful admin login
- Add missing `exit;` statements after login-related redirects

## Testing
- `phpunit --configuration tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_b_688e629ffccc8331b096b5345e107d19