### PR TITLE
Validate reservation inputs and add structured error handling

### DIFF
--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/submit-reservation.php
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/submit-reservation.php
@@ -1,9 +1,12 @@
 <?php
 require_once __DIR__ . '/includes/class-database.php';
 
+header('Content-Type: application/json');
+
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
-  http_response_code(405);
-  exit('Invalid request');
+    http_response_code(405);
+    echo json_encode(['status' => 'error', 'message' => 'Invalid request method.']);
+    exit;
 }
 
 $name   = $_POST['name'] ?? '';
@@ -13,18 +16,53 @@ $date   = $_POST['date'] ?? '';
 $time   = $_POST['time'] ?? '';
 $guests = $_POST['guests'] ?? 1;
 
-if (!$name || !$email || !$phone || !$date || !$time || !$guests) {
-  die("Missing required fields.");
+$errors = [];
+
+if (!$name) {
+    $errors[] = 'Name is required.';
+}
+
+if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    $errors[] = 'A valid email is required.';
+}
+
+if (!preg_match('/^\+?[0-9\s\-()]{7,}$/', $phone)) {
+    $errors[] = 'A valid phone number is required.';
+}
+
+if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $date)) {
+    $errors[] = 'A valid date is required.';
+}
+
+if (!preg_match('/^\d{2}:\d{2}$/', $time)) {
+    $errors[] = 'A valid time is required.';
+}
+
+if (!filter_var($guests, FILTER_VALIDATE_INT) || $guests <= 0) {
+    $errors[] = 'Guest count must be a positive integer.';
+}
+
+if ($errors) {
+    http_response_code(400);
+    echo json_encode(['status' => 'error', 'message' => implode(' ', $errors)]);
+    exit;
 }
 
 try {
-  $db = new Database();
-  $pdo = $db->connect();
+    $db  = new Database();
+    $pdo = $db->connect();
 
-  $stmt = $pdo->prepare("INSERT INTO reservations (name, email, phone, date, time, guests, status) VALUES (?, ?, ?, ?, ?, ?, 'Pending')");
-  $stmt->execute([$name, $email, $phone, $date, $time, $guests]);
+    $stmt = $pdo->prepare(
+        "INSERT INTO reservations (name, email, phone, date, time, guests, status) VALUES (?, ?, ?, ?, ?, ?, 'Pending')"
+    );
+    $stmt->execute([$name, $email, $phone, $date, $time, $guests]);
 
-  echo "<script>alert('Reservation submitted!');window.location.href='public-reservation-form.php';</script>";
+    echo json_encode(['status' => 'success', 'message' => 'Reservation submitted!']);
 } catch (Exception $e) {
-  die("Error saving reservation: " . $e->getMessage());
+    error_log('Error saving reservation: ' . $e->getMessage());
+    http_response_code(500);
+    echo json_encode([
+        'status'  => 'error',
+        'message' => 'An unexpected error occurred. Please try again later.',
+    ]);
 }


### PR DESCRIPTION
## Summary
- Add server-side validation for reservation fields
- Replace die calls with JSON error responses
- Log unexpected exceptions without revealing details

## Testing
- `phpunit --configuration tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_b_688e66fc39048331a0055d36ede0fe41