### PR TITLE
Add CSRF protection and sanitize login inputs

### DIFF
--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/login.php
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/login.php
@@ -4,6 +4,16 @@ if (isset($_SESSION['admin_logged_in'])) {
   header("Location: views/admin/dashboard.php");
   exit;
 }
+
+// Prepare a CSRF token using a WordPress nonce when available.
+if (function_exists('wp_create_nonce')) {
+  $yenolx_nonce = wp_create_nonce('yenolx_admin_login');
+} else {
+  if (empty($_SESSION['yenolx_login_nonce'])) {
+    $_SESSION['yenolx_login_nonce'] = bin2hex(random_bytes(32));
+  }
+  $yenolx_nonce = $_SESSION['yenolx_login_nonce'];
+}
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -23,6 +33,7 @@ if (isset($_SESSION['admin_logged_in'])) {
             <div class="alert alert-danger">Invalid credentials</div>
           <?php endif; ?>
           <form method="POST" action="process-login.php">
+            <input type="hidden" name="yenolx_login_nonce" value="<?php echo htmlspecialchars($yenolx_nonce, ENT_QUOTES, 'UTF-8'); ?>">
             <div class="mb-3">
               <label class="form-label">Username</label>
               <input type="text" name="username" class="form-control" required>

--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/process-login.php
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/process-login.php
@@ -4,6 +4,33 @@ require_once __DIR__ . '/includes/class-database.php';
 
 $username = $_POST['username'] ?? '';
 $password = $_POST['password'] ?? '';
+$nonce    = $_POST['yenolx_login_nonce'] ?? '';
+
+// Verify CSRF token using a WordPress nonce when available.
+if (function_exists('wp_verify_nonce')) {
+  if (!wp_verify_nonce($nonce, 'yenolx_admin_login')) {
+    header("Location: login.php?error=csrf");
+    exit;
+  }
+} else {
+  if (empty($_SESSION['yenolx_login_nonce']) || !hash_equals($_SESSION['yenolx_login_nonce'], $nonce)) {
+    header("Location: login.php?error=csrf");
+    exit;
+  }
+}
+
+// Sanitize user input before using in database queries.
+if (function_exists('sanitize_user')) {
+  $username = sanitize_user($username);
+} else {
+  $username = filter_var($username, FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+}
+
+if (function_exists('sanitize_text_field')) {
+  $password = sanitize_text_field($password);
+} else {
+  $password = filter_var($password, FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+}
 
 $db = new Database();
 $pdo = $db->connect();


### PR DESCRIPTION
## Summary
- Add WordPress nonce generation to login form and include hidden field
- Verify nonce and sanitize username/password inputs before DB query
- Reject login requests when CSRF token check fails

## Testing
- `php -l 'Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/login.php'`
- `php -l 'Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/process-login.php'`
- `phpunit --configuration tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_b_688e7a65da608331ad337432289dbfd9