### PR TITLE
Add nonce and sanitize reset password inputs

### DIFF
--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/process-reset-password.php
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/process-reset-password.php
@@ -3,18 +3,27 @@ session_start();
 require_once __DIR__ . '/includes/auth-check.php';
 require_once __DIR__ . '/includes/class-database.php';
 
-$current = $_POST['current_password'] ?? '';
-$new = $_POST['new_password'] ?? '';
-$confirm = $_POST['confirm_password'] ?? '';
+if (
+    !isset($_POST['nonce'], $_SESSION['reset_password_nonce']) ||
+    !hash_equals($_SESSION['reset_password_nonce'], $_POST['nonce'])
+) {
+    header("Location: reset-password.php?error=" . urlencode('Invalid request'));
+    exit;
+}
+unset($_SESSION['reset_password_nonce']);
+
+$current = trim(filter_input(INPUT_POST, 'current_password', FILTER_SANITIZE_STRING) ?? '');
+$new = trim(filter_input(INPUT_POST, 'new_password', FILTER_SANITIZE_STRING) ?? '');
+$confirm = trim(filter_input(INPUT_POST, 'confirm_password', FILTER_SANITIZE_STRING) ?? '');
 $user = $_SESSION['admin_username'];
 
 if (!$current || !$new || !$confirm) {
-  header("Location: reset-password.php?error=Missing fields");
+  header("Location: reset-password.php?error=" . urlencode('Missing fields'));
   exit;
 }
 
 if ($new !== $confirm) {
-  header("Location: reset-password.php?error=Passwords do not match");
+  header("Location: reset-password.php?error=" . urlencode('Passwords do not match'));
   exit;
 }
 
@@ -27,7 +36,7 @@ try {
   $row = $stmt->fetch(PDO::FETCH_ASSOC);
 
   if (!$row || !password_verify($current, $row['password'])) {
-    header("Location: reset-password.php?error=Incorrect current password");
+    header("Location: reset-password.php?error=" . urlencode('Incorrect current password'));
     exit;
   }
 
@@ -38,6 +47,6 @@ try {
   header("Location: reset-password.php?success=1");
   exit;
 } catch (Exception $e) {
-  header("Location: reset-password.php?error=Error: " . urlencode($e->getMessage()));
+  header("Location: reset-password.php?error=" . urlencode('Error: ' . $e->getMessage()));
   exit;
 }

--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/reset-password.php
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/reset-password.php
@@ -1,6 +1,10 @@
 <?php
 require_once __DIR__ . '/includes/auth-check.php';
 session_start();
+if (empty($_SESSION['reset_password_nonce'])) {
+    $_SESSION['reset_password_nonce'] = bin2hex(random_bytes(32));
+}
+$nonce = $_SESSION['reset_password_nonce'];
 ?>
 
 <!DOCTYPE html>
@@ -23,6 +27,7 @@ session_start();
             <div class="alert alert-danger"><?= htmlspecialchars($_GET['error']) ?></div>
           <?php endif; ?>
           <form method="POST" action="process-reset-password.php">
+            <input type="hidden" name="nonce" value="<?= htmlspecialchars($nonce) ?>">
             <div class="mb-3">
               <label>Current Password</label>
               <input type="password" name="current_password" class="form-control" required>


### PR DESCRIPTION
## Summary
- sanitize all password reset POST inputs
- add nonce generation and verification around reset password form
- encode redirect errors for safe display

## Testing
- `php -l 'Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/process-reset-password.php'`
- `php -l 'Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/reset-password.php'`
- `phpunit --configuration tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_b_688e7a783fe88331b1cee9e18b0dd657