### PR TITLE
Always prepare hours query

### DIFF
--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/models/class-hours-model.php
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/models/class-hours-model.php
@@ -108,12 +108,9 @@ class YRR_Hours_Model {
         }
         
         $sql .= " ORDER BY FIELD(day_of_week, 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday')";
-        
-        if (!empty($params)) {
-            $sql = $wpdb->prepare($sql, $params);
-        }
-        
-        return $wpdb->get_results($sql);
+
+        // Use prepare even when there are no bound values for consistency
+        return $wpdb->get_results($wpdb->prepare($sql, $params ?: []));
     }
     
     /**


### PR DESCRIPTION
## Summary
- Always call `prepare` when fetching hours, even without bound values
- Document that the query is prepared even with no parameters

## Testing
- `php -l "Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/models/class-hours-model.php"`
- `phpunit --configuration tests/phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_688e86f6cc108331825c3b4e43098e79