### PR TITLE
Ensure queries use prepared statements in settings and locations models

### DIFF
--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/models/class-locations-model.php
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/models/class-locations-model.php
@@ -166,9 +166,10 @@ class YRR_Locations_Model {
             $where_sql = "WHERE is_active = 1";
         }
         
-        return $wpdb->get_results(
-            "SELECT * FROM " . YRR_LOCATIONS_TABLE . " $where_sql ORDER BY sort_order ASC, name ASC"
-        );
+        $sql = "SELECT * FROM " . YRR_LOCATIONS_TABLE . " $where_sql ORDER BY sort_order ASC, name ASC";
+        // Prepare is used even without dynamic parameters to enforce safe query construction
+        // and maintain consistency with WordPress database practices.
+        return $wpdb->get_results($wpdb->prepare($sql, []));
     }
     
     /**

--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/models/class-settings-model.php
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/models/class-settings-model.php
@@ -82,8 +82,13 @@ class YRR_Settings_Model {
     public static function get_all_settings() {
         global $wpdb;
         
+        // Prepared statement ensures query safety and future-proofs against injection even
+        // when the current query uses only static values.
         $results = $wpdb->get_results(
-            "SELECT setting_key, setting_value FROM " . YRR_SETTINGS_TABLE . " WHERE autoload = 1",
+            $wpdb->prepare(
+                "SELECT setting_key, setting_value FROM " . YRR_SETTINGS_TABLE . " WHERE autoload = %d",
+                1
+            ),
             ARRAY_A
         );
         


### PR DESCRIPTION
## Summary
- Use `$wpdb->prepare` for loading autoloaded settings
- Wrap locations query in a prepared statement for safe execution
- Comment why prepared statements are used even without user input

## Testing
- `phpunit --configuration tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_b_688e86fa00f88331b9ade684104c38dd