### PR TITLE
Remove redundant PHP opening tags in admin views

### DIFF
--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/all-reservations.php
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/all-reservations.php
@@ -1,4 +1,3 @@
-<?php
 <?php include_once('../../includes/auth-check.php'); ?>
 <a href="../../reset-password.php" class="btn btn-outline-secondary">Change Password</a>
 

--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/analytics.php
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/analytics.php
@@ -1,4 +1,3 @@
-<?php
 <?php include_once('../../includes/auth-check.php'); ?>
 <a href="../../reset-password.php" class="btn btn-outline-secondary">Change Password</a>
 

--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/calendar.php
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/calendar.php
@@ -1,5 +1,4 @@
-<?php
-include_once('../../includes/auth-check.php');
+<?php include_once('../../includes/auth-check.php');
 
 /**
  * Weekly Calendar Admin View - Clean and Professional

--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/coupons.php
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/coupons.php
@@ -1,4 +1,3 @@
-<?php
 <?php include_once('../../includes/auth-check.php'); ?>
 <a href="../../reset-password.php" class="btn btn-outline-secondary">Change Password</a>
 

--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/dashboard.php
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/dashboard.php
@@ -1,4 +1,3 @@
-<?php
 <?php include_once('../../includes/auth-check.php'); ?>
 <a href="../../reset-password.php" class="btn btn-outline-secondary">Change Password</a>
 

--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/hours.php
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/hours.php
@@ -1,4 +1,3 @@
-<?php
 <?php include_once('../../includes/auth-check.php'); ?>
 <a href="../../reset-password.php" class="btn btn-outline-secondary">Change Password</a>
 

--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/locations.php
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/locations.php
@@ -1,4 +1,3 @@
-<?php
 <?php include_once('../../includes/auth-check.php'); ?>
 <a href="../../reset-password.php" class="btn btn-outline-secondary">Change Password</a>
 

--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/reservations.php
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/reservations.php
@@ -1,4 +1,3 @@
-<?php
 <?php include_once('../../includes/auth-check.php'); ?>
 <a href="../../reset-password.php" class="btn btn-outline-secondary">Change Password</a>
 

--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/schedule.php
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/schedule.php
@@ -1,5 +1,4 @@
-<?php
-include_once('../../includes/auth-check.php');
+<?php include_once('../../includes/auth-check.php');
 
 if (!defined('ABSPATH')) exit;
 

--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/settings.php
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/settings.php
@@ -1,4 +1,3 @@
-<?php
 <?php include_once('../../includes/auth-check.php'); ?>
 <a href="../../reset-password.php" class="btn btn-outline-secondary">Change Password</a>
 

--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/tables.php
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/tables.php
@@ -1,5 +1,4 @@
-<?php
-include_once('../../includes/auth-check.php');
+<?php include_once('../../includes/auth-check.php');
 
 if (!defined('ABSPATH')) exit;
 

--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/weekly.php
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/weekly.php
@@ -1,4 +1,3 @@
-<?php
 <?php include_once('../../includes/auth-check.php'); ?>
 <a href="../../reset-password.php" class="btn btn-outline-secondary">Change Password</a>
 


### PR DESCRIPTION
## Summary
- streamline admin view headers by removing redundant PHP opening tags
- ensure each admin template starts with a single tag and authentication include

## Testing
- `phpunit --configuration tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_b_688e9bb156a8833190221b954480b45b