### PR TITLE
Use require_once for admin auth check

### DIFF
--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/all-reservations.php
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/all-reservations.php
@@ -1,5 +1,4 @@
-<?php
-<?php include_once('../../includes/auth-check.php'); ?>
+<?php require_once __DIR__ . '/../../includes/auth-check.php'; ?>
 <a href="../../reset-password.php" class="btn btn-outline-secondary">Change Password</a>
 
 if (!defined('ABSPATH')) exit;

--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/analytics.php
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/analytics.php
@@ -1,5 +1,4 @@
-<?php
-<?php include_once('../../includes/auth-check.php'); ?>
+<?php require_once __DIR__ . '/../../includes/auth-check.php'; ?>
 <a href="../../reset-password.php" class="btn btn-outline-secondary">Change Password</a>
 
 if (!defined('ABSPATH')) exit;

--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/calendar.php
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/calendar.php
@@ -1,5 +1,5 @@
 <?php
-include_once('../../includes/auth-check.php');
+require_once __DIR__ . '/../../includes/auth-check.php';
 
 /**
  * Weekly Calendar Admin View - Clean and Professional

--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/coupons.php
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/coupons.php
@@ -1,5 +1,4 @@
-<?php
-<?php include_once('../../includes/auth-check.php'); ?>
+<?php require_once __DIR__ . '/../../includes/auth-check.php'; ?>
 <a href="../../reset-password.php" class="btn btn-outline-secondary">Change Password</a>
 
 if (!defined('ABSPATH')) exit;

--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/dashboard.php
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/dashboard.php
@@ -1,5 +1,4 @@
-<?php
-<?php include_once('../../includes/auth-check.php'); ?>
+<?php require_once __DIR__ . '/../../includes/auth-check.php'; ?>
 <a href="../../reset-password.php" class="btn btn-outline-secondary">Change Password</a>
 
 if (!defined('ABSPATH')) exit;

--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/hours.php
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/hours.php
@@ -1,5 +1,4 @@
-<?php
-<?php include_once('../../includes/auth-check.php'); ?>
+<?php require_once __DIR__ . '/../../includes/auth-check.php'; ?>
 <a href="../../reset-password.php" class="btn btn-outline-secondary">Change Password</a>
 
 if (!defined('ABSPATH')) exit;

--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/locations.php
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/locations.php
@@ -1,5 +1,4 @@
-<?php
-<?php include_once('../../includes/auth-check.php'); ?>
+<?php require_once __DIR__ . '/../../includes/auth-check.php'; ?>
 <a href="../../reset-password.php" class="btn btn-outline-secondary">Change Password</a>
 
 if (!defined('ABSPATH')) exit;

--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/reservations.php
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/reservations.php
@@ -1,5 +1,4 @@
-<?php
-<?php include_once('../../includes/auth-check.php'); ?>
+<?php require_once __DIR__ . '/../../includes/auth-check.php'; ?>
 <a href="../../reset-password.php" class="btn btn-outline-secondary">Change Password</a>
 
 /**

--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/schedule.php
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/schedule.php
@@ -1,5 +1,5 @@
 <?php
-include_once('../../includes/auth-check.php');
+require_once __DIR__ . '/../../includes/auth-check.php';
 
 if (!defined('ABSPATH')) exit;
 

--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/settings.php
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/settings.php
@@ -1,5 +1,4 @@
-<?php
-<?php include_once('../../includes/auth-check.php'); ?>
+<?php require_once __DIR__ . '/../../includes/auth-check.php'; ?>
 <a href="../../reset-password.php" class="btn btn-outline-secondary">Change Password</a>
 
 if (!defined('ABSPATH')) exit;

--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/tables.php
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/tables.php
@@ -1,5 +1,5 @@
 <?php
-include_once('../../includes/auth-check.php');
+require_once __DIR__ . '/../../includes/auth-check.php';
 
 if (!defined('ABSPATH')) exit;
 

--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/weekly.php
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/weekly.php
@@ -1,5 +1,4 @@
-<?php
-<?php include_once('../../includes/auth-check.php'); ?>
+<?php require_once __DIR__ . '/../../includes/auth-check.php'; ?>
 <a href="../../reset-password.php" class="btn btn-outline-secondary">Change Password</a>
 
 


### PR DESCRIPTION
## Summary
- use `require_once` with absolute path for admin auth checks
- clean up redundant PHP opening tags in admin views

## Testing
- `php -l Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/*.php`

------
https://chatgpt.com/codex/tasks/task_b_688e9bcbd6c88331bbcb472ca6019db1