### PR TITLE
refactor: replace float-based layout for location filter

### DIFF
--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/assets/admin.css
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/assets/admin.css
@@ -18,10 +18,27 @@
     line-height: 1.3;
 }
 
-/* ===== LOCATION FILTER ===== */
+/* ===== ADMIN HEADER ===== */
+.yrr-header-bar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 15px;
+    margin: 0 0 20px;
+}
+
+.yrr-header-title {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+}
+
 .yrr-location-filter {
-    float: right;
-    margin: -50px 0 20px 0;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 0;
 }
 
 .yrr-location-filter select {

--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/calendar.php
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/views/admin/calendar.php
@@ -54,11 +54,30 @@ $next_week = date('Y-m-d', strtotime($week_start.' +7 days'));
 $days = array('Monday','Tuesday','Wednesday','Thursday','Friday','Saturday','Sunday');
 ?>
 <div class="yrr-admin-wrap yrr-calendar-wrap">
-    <h1 class="wp-heading-inline"><?php _e('Reservations Calendar', 'yrr'); ?></h1>
-    <a href="#" class="page-title-action yrr-btn-create-reservation">
-        <span class="dashicons dashicons-plus-alt"></span>
-        <?php _e('Add New Reservation', 'yrr'); ?>
-    </a>
+    <div class="yrr-header-bar">
+        <div class="yrr-header-title">
+            <h1 class="wp-heading-inline"><?php _e('Reservations Calendar', 'yrr'); ?></h1>
+            <a href="#" class="page-title-action yrr-btn-create-reservation">
+                <span class="dashicons dashicons-plus-alt"></span>
+                <?php _e('Add New Reservation', 'yrr'); ?>
+            </a>
+        </div>
+        <?php if(count($locations)>1): ?>
+            <form method="get" class="yrr-location-filter">
+                <input type="hidden" name="page" value="yrr-calendar">
+                <input type="hidden" name="week" value="<?php echo esc_attr($current_week); ?>">
+                <label for="location_filter"><?php _e('Location:', 'yrr'); ?></label>
+                <select name="location_id" id="location_filter" onchange="this.form.submit()">
+                    <option value=""><?php _e('All Locations', 'yrr'); ?></option>
+                    <?php foreach ($locations as $loc): ?>
+                        <option value="<?php echo esc_attr($loc->id); ?>" <?php selected($location_id, $loc->id); ?>>
+                            <?php echo esc_html($loc->name); ?>
+                        </option>
+                    <?php endforeach; ?>
+                </select>
+            </form>
+        <?php endif; ?>
+    </div>
     <hr class="wp-header-end">
     <div class="yrr-calendar-header">
         <div class="yrr-calendar-nav">
@@ -75,23 +94,6 @@ $days = array('Monday','Tuesday','Wednesday','Thursday','Friday','Saturday','Sun
                 <?php _e('Next Week', 'yrr'); ?> <span class="dashicons dashicons-arrow-right-alt2"></span>
             </a>
         </div>
-        <?php if(count($locations)>1): ?>
-        <div>
-            <form method="get" class="yrr-location-filter" style="margin:0;">
-                <input type="hidden" name="page" value="yrr-calendar">
-                <input type="hidden" name="week" value="<?php echo esc_attr($current_week); ?>">
-                <label for="location_filter"><?php _e('Location:', 'yrr'); ?></label>
-                <select name="location_id" id="location_filter" onchange="this.form.submit()">
-                    <option value=""><?php _e('All Locations', 'yrr'); ?></option>
-                    <?php foreach ($locations as $loc): ?>
-                        <option value="<?php echo esc_attr($loc->id); ?>" <?php selected($location_id, $loc->id); ?>>
-                            <?php echo esc_html($loc->name); ?>
-                        </option>
-                    <?php endforeach; ?>
-                </select>
-            </form>
-        </div>
-        <?php endif; ?>
     </div>
     <div class="yrr-week-stats">
         <div class="yrr-stats-grid">


### PR DESCRIPTION
## Summary
- simplify admin header by using flex-based layout instead of floats
- wrap calendar heading and location filter in a flexible container for responsive alignment

## Testing
- `phpunit --configuration tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_b_688e9bcd1f388331a67df2768ffa8e8f