### PR TITLE
Remove redundant session start in reset password flow

### DIFF
--- a/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/reset-password.php
+++ b/Yenolx Restaurant Reservation System/Yenolx Restaurant Reservation System/reset-password.php
@@ -1,6 +1,5 @@
 <?php
 require_once __DIR__ . '/includes/auth-check.php';
-session_start();
 if (empty($_SESSION['reset_password_nonce'])) {
     $_SESSION['reset_password_nonce'] = bin2hex(random_bytes(32));
 }


### PR DESCRIPTION
## Summary
- avoid duplicate session initialization in reset-password.php since auth-check.php already calls `session_start`

## Testing
- `php /tmp/check_session.php`
- `phpunit --configuration tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_b_688e9bce64b4833194da8c81b9ddebb1